### PR TITLE
Remove useless parent in suggestion item

### DIFF
--- a/library/src/main/res/layout/search_suggestion_item.xml
+++ b/library/src/main/res/layout/search_suggestion_item.xml
@@ -3,55 +3,49 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:minHeight="56dp"
+    android:orientation="horizontal">
 
-    <LinearLayout
-        android:layout_width="match_parent"
+    <ImageView
+        android:id="@+id/left_icon"
+        android:layout_width="@dimen/square_button_size"
+        android:layout_height="@dimen/square_button_size"
+        android:layout_gravity="center"
+        android:layout_marginStart="@dimen/search_bar_left_icon_left_margin"
+        android:layout_marginLeft="@dimen/search_bar_left_icon_left_margin"
+        android:alpha="1"
+        android:padding="@dimen/square_button_padding"
+        android:visibility="visible"
+        tools:src="@tools:sample/avatars" />
+
+    <TextView
+        android:id="@+id/body"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:minHeight="56dp"
-        android:orientation="horizontal">
+        android:layout_gravity="start|center"
+        android:layout_marginStart="@dimen/search_bar_search_input_left_margin"
+        android:layout_marginLeft="@dimen/search_bar_search_input_left_margin"
+        android:layout_weight="1"
+        android:ellipsize="end"
+        android:gravity="start|center"
+        android:paddingTop="4dp"
+        android:paddingBottom="4dp"
+        android:textSize="@dimen/suggestion_body_text_size"
+        tools:text="@tools:sample/full_names" />
 
-        <ImageView
-            android:id="@+id/left_icon"
-            android:layout_width="@dimen/square_button_size"
-            android:layout_height="@dimen/square_button_size"
-            android:layout_gravity="center"
-            android:layout_marginStart="@dimen/search_bar_left_icon_left_margin"
-            android:layout_marginLeft="@dimen/search_bar_left_icon_left_margin"
-            android:alpha="1"
-            android:padding="@dimen/square_button_padding"
-            android:visibility="visible"
-            tools:src="@tools:sample/avatars" />
+    <ImageView
+        android:id="@+id/right_icon"
+        android:layout_width="@dimen/square_button_size"
+        android:layout_height="@dimen/square_button_size"
+        android:layout_gravity="center"
+        android:layout_marginEnd="@dimen/search_bar_right_icon_right_margin"
+        android:layout_marginRight="@dimen/search_bar_right_icon_right_margin"
+        android:alpha="1"
+        android:background="@drawable/oval_btn_selector"
+        android:padding="@dimen/square_button_padding"
+        android:src="@drawable/ic_arrow_back_black_24dp"
+        android:visibility="visible"
+        tools:rotation="45"
+        tools:tint="@color/background" />
 
-        <TextView
-            android:id="@+id/body"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_gravity="start|center"
-            android:layout_marginStart="@dimen/search_bar_search_input_left_margin"
-            android:layout_marginLeft="@dimen/search_bar_search_input_left_margin"
-            android:layout_weight="1"
-            android:ellipsize="end"
-            android:gravity="start|center"
-            android:paddingTop="4dp"
-            android:paddingBottom="4dp"
-            android:textSize="@dimen/suggestion_body_text_size"
-            tools:text="@tools:sample/full_names" />
-
-        <ImageView
-            android:id="@+id/right_icon"
-            android:layout_width="@dimen/square_button_size"
-            android:layout_height="@dimen/square_button_size"
-            android:layout_gravity="center"
-            android:layout_marginEnd="@dimen/search_bar_right_icon_right_margin"
-            android:layout_marginRight="@dimen/search_bar_right_icon_right_margin"
-            android:alpha="1"
-            android:background="@drawable/oval_btn_selector"
-            android:padding="@dimen/square_button_padding"
-            android:src="@drawable/ic_arrow_back_black_24dp"
-            android:visibility="visible"
-            tools:rotation="45"
-            tools:tint="@color/background" />
-
-    </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
Lint fix since divider approach was moved to decoration, extra parent should have been removed which was holding the previous divider approach in suggestion item xml.