### PR TITLE
disable long press and text selection because of a bunch of crashes: …

### DIFF
--- a/library/src/main/java/com/arlib/floatingsearchview/util/view/SearchInputView.java
+++ b/library/src/main/java/com/arlib/floatingsearchview/util/view/SearchInputView.java
@@ -2,6 +2,8 @@ package com.arlib.floatingsearchview.util.view;
 
 import android.content.Context;
 import androidx.appcompat.widget.AppCompatEditText;
+
+import android.os.Build;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
 import android.view.View;
@@ -40,7 +42,15 @@ public class SearchInputView extends AppCompatEditText {
 
     private void init() {
         setOnKeyListener(mOnKeyListener);
-        setTextIsSelectable(true);
+
+        //disable long press and text selection because of a bunch of crashes: https://console.firebase.google.com/u/1/project/api-project-1068643720791/crashlytics/app/android:com.viki.android/issues?state=open&time=last-seven-days&type=crash&issuesQuery=editor.java
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            setTextIsSelectable(false);
+            setLongClickable(false);
+        }
+        else {
+            setTextIsSelectable(true);
+        }
     }
 
     @Override

--- a/library/src/main/res/layout/search_query_section.xml
+++ b/library/src/main/res/layout/search_query_section.xml
@@ -61,7 +61,6 @@
                 android:hint="@string/abc_search_hint"
                 android:imeOptions="actionSearch"
                 android:inputType="textNoSuggestions"
-                android:longClickable="false"
                 android:maxLines="1"
                 android:minHeight="@dimen/square_button_size"
                 android:singleLine="true" />


### PR DESCRIPTION
…https://console.firebase.google.com/u/1/project/api-project-1068643720791/crashlytics/app/android:com.viki.android/issues?state=open&time=last-seven-days&type=crash&issuesQuery=editor.java